### PR TITLE
draws the side labels as lowest(first) layer, so large tooltip select…

### DIFF
--- a/lib/widgets/chart.dart
+++ b/lib/widgets/chart.dart
@@ -72,7 +72,10 @@ class Chart extends StatelessWidget {
         onSelectionChanged: onSelectionChanged,
         builder: (context, selectedX) => Stack(
           fit: StackFit.expand,
-          children: layers
+          children: [leftLabels, rightLabels, topLabels, bottomLabels]
+                  .whereNotNull()
+                  .toList() +
+                  layers
                   .map(
                     (layer) => getLayerWidget(
                       context,
@@ -83,11 +86,7 @@ class Chart extends StatelessWidget {
                       selectedX,
                       contentPadding,
                     ),
-                  )
-                  .toList() +
-              [leftLabels, rightLabels, topLabels, bottomLabels]
-                  .whereNotNull()
-                  .toList(),
+                  ).toList(),
         ),
       ),
     );


### PR DESCRIPTION
This draws the side labels as lowest(first) layer, so large tooltip selection widgets are painted on top
rather than being rendered _under_ the edge labels, for better tooltip readability at the edges.
All I did was change the order of the layers' rendering.

This addresses the overlap I described in #2 
 

